### PR TITLE
Add _ to the allowed characters in YouTube video ID

### DIFF
--- a/specification/appdf-description.xsd
+++ b/specification/appdf-description.xsd
@@ -180,7 +180,7 @@
   
   <xsd:simpleType name="type-attr-youtubeid">
     <xsd:restriction base="xsd:string">
-      <xsd:pattern value="[a-zA-Z0-9\-]{11}"/>
+      <xsd:pattern value="[a-zA-Z0-9_\-]{11}"/>
     </xsd:restriction>
   </xsd:simpleType>  
   


### PR DESCRIPTION
I found this VP9YKhCm-_4 is a valid YouTube ID.
