### PR TITLE
Fixes in store categories

### DIFF
--- a/specification/data/store_categories.json
+++ b/specification/data/store_categories.json
@@ -568,6 +568,15 @@
         }
     },
     "Health" : {
+        "" : {
+          "google" : "Health & Fitness",
+          "amazon" : "Health & Fitness / Medical",
+          "opera" : "Health",
+          "yandex" : "Health",
+          "samsung" : "Health/Fitness",
+          "appland" : "Health & Fitness / Misc",
+          "slideme" : "Health & Fitness / Other"
+        },
         "Exercise" : {
           "google" : "Health & Fitness",
           "amazon" : "Health & Fitness / Exercise & Fitness",
@@ -1659,18 +1668,18 @@
         }
     },
     "Travel" : {
-        "Transportation" : {
-          "google" : "Transportation",
-          "amazon" : "Travel / Transportation",
+        "" : {
+          "google" : "Travel & Local",
+          "amazon" : "Travel / Other",
           "opera" : "Travel & Maps",
           "yandex" : "Travel & Maps",
           "samsung" : "Travel",
           "appland" : "Lifestyle / Travel",
           "slideme" : "Travel & Locality / Other"
         },
-        "" : {
-          "google" : "Travel & Local",
-          "amazon" : "Travel / Other",
+        "Transportation" : {
+          "google" : "Transportation",
+          "amazon" : "Travel / Transportation",
           "opera" : "Travel & Maps",
           "yandex" : "Travel & Maps",
           "samsung" : "Travel",


### PR DESCRIPTION
The AppDF PHP parser (maybe ohters, too) expect the first subcategory to be "" in order to map subcategories correctly. This patch fixes a couple of problems with Health and Transportation categories, which made all Heath subcategories to fall under Graphical novels and Transportation under Sports, affecting all stores.
